### PR TITLE
SAPCAR magic correct + MIME type

### DIFF
--- a/magic/Magdir/archive
+++ b/magic/Magdir/archive
@@ -802,7 +802,11 @@
 0	string	NSK NaShrink archive data
 # SAPCAR
 0	string	#\ CAR\ archive\ header SAPCAR archive data
-0	string	CAR\ 2.00RG SAPCAR archive data
+0	string	CAR\ 2.00 SAPCAR archive data
+0	string	CAR\ 2.01 SAPCAR archive data
+#!:mime	application/octet-stream
+!:mime	application/vnd.sar
+!:ext	sar
 # Disintegrator
 0	string	DST Disintegrator archive data
 # ASD


### PR DESCRIPTION
official magic for *.sar file
- \x43\x41\x52\x20\x32\x2E\x30\x30  (CAR 2.00)
- \x43\x41\x52\x20\x32\x2E\x30\x31  (CAR 2.01)

The RG was part of TOC already
Add MIME Type https://www.iana.org/assignments/media-types/application/vnd.sar